### PR TITLE
Remove nightly feature for duration division

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![feature(div_duration)]
-#![feature(is_some_and)]
-    
-
 //! Library which implements the core
 //! [GCRA](https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm) functionality in rust.
 //!
@@ -59,4 +55,4 @@ mod rate_limiter;
 pub use crate::gcra::{GcraError, GcraState};
 pub use crate::rate_limit::RateLimit;
 #[cfg(feature = "rate-limiter")]
-pub use crate::rate_limiter::{RateLimiter, RateLimitEntry, RateLimitRequest};
+pub use crate::rate_limiter::{RateLimitEntry, RateLimitRequest, RateLimiter};


### PR DESCRIPTION
Removes `#![feature(div_duration)]` so we can use it in stable builds.

We use `gcra` for rate limiting in https://github.com/aakoshh/ipc-ipld-resolver